### PR TITLE
Add New Enum Values to Food and Talent Types

### DIFF
--- a/src/components/GameArea/GameArea.tsx
+++ b/src/components/GameArea/GameArea.tsx
@@ -47,6 +47,7 @@ const GameArea = ({
     [TalentType.ElementalBurst]: "Elemental Burst",
     [TalentType.FirstAscensionPassive]: "1st Ascension Passive",
     [TalentType.FourthAscensionPassive]: "4th Ascension Passive",
+    [TalentType.NightRealmsGiftPassive]: "Night Realm's Gift Passive",
     [TalentType.UtilityPassive]: "Utility Passive",
     [TalentType.Passive]: "Passive",
   };

--- a/src/components/GuessTableRow/GuessTableRow.tsx
+++ b/src/components/GuessTableRow/GuessTableRow.tsx
@@ -39,6 +39,7 @@ const GuessTableRow = memo(
       [FoodType.AtkBoostingDishes]: "ATK-Boosting Dishes",
       [FoodType.Potions]: "Potions",
       [FoodType.EssentialOils]: "Essential Oils",
+      [FoodType.OtherDishes]: "Other Dishes",
     };
 
     const statEnumMap = {

--- a/src/tests/components/GameArea.test.tsx
+++ b/src/tests/components/GameArea.test.tsx
@@ -124,7 +124,7 @@ const foodData: FoodData[] = [
     foodId: "1",
     foodName: "Paimon (Emergency Food)",
     rarity: 5,
-    foodType: FoodType.AdventurersDishes,
+    foodType: FoodType.OtherDishes,
     specialDish: false,
     purchasable: false,
     recipe: false,
@@ -137,7 +137,7 @@ const talentData: TalentData[] = [
   {
     talentId: "1",
     talentName: "Eat",
-    talentType: TalentType.NormalAttack,
+    talentType: TalentType.NightRealmsGiftPassive,
     talentImageUrl: "dummy talent",
     characterName: "Paimon",
     characterImageUrl: "dummy",
@@ -400,7 +400,7 @@ describe("If complete is true and gameType is talent or constellation...", () =>
       />
     );
     const talentInfo = screen.getByRole("heading", {
-      name: "Paimon's Normal Attack Talent: Eat",
+      name: "Paimon's Night Realm's Gift Passive Talent: Eat",
     });
     expect(talentInfo).toBeInTheDocument();
   });


### PR DESCRIPTION
Render the new Food and Talent type enum values added in [this PR](https://github.com/thebrianwong/teyvatdle-genshin-api/pull/6) on the backend. The food type is handled in the food version's "food type" cell. The talent type is handled in the talent version when the user guesses the correct character and the talent details are revealed.